### PR TITLE
Changed Similarity  threshold value to double

### DIFF
--- a/src/main/java/com/edduarte/similarity/Similarity.java
+++ b/src/main/java/com/edduarte/similarity/Similarity.java
@@ -357,7 +357,7 @@ public interface Similarity<T> {
          * A threshold S that balances the number of false positives and false
          * negatives.
          */
-        public LSHFactory withThreshold(int threshold) {
+        public LSHFactory withThreshold(double threshold) {
             this.s = threshold;
             return this;
         }


### PR DESCRIPTION
withThreshold method in Similarity.java accepts an int value and sets it to a double value. I changed so that the method itself would accept a double value.